### PR TITLE
Added failOnStderr

### DIFF
--- a/ci/sign-all-tasks.yml
+++ b/ci/sign-all-tasks.yml
@@ -31,4 +31,5 @@ steps:
 - script: del ${{ parameters.layoutRoot }}\CodeSignSummary*.md
   displayName: Remove CodeSignSummary file from package folder
   condition: and(succeeded(), ne(variables['build.reason'], 'PullRequest'), ne(variables['numTasks'], 0), eq(variables.os, 'Windows_NT'))
+  failOnStderr: true
 


### PR DESCRIPTION
Adding failOnStderr should hopefully cause the error to appear in the correct place in the CI.

**Task name**:  Your CI

**Description**: Simply adds `failOnStderr` to the step so that it fails when it can't delete the summary file. A real fix would be to make it retry but didn't know if you want to support multi-os given you use `script` rather than `pwsh`

**Documentation changes required:** N (although some explanation of why you can't toggle output of the file from the Internal tool might be nice).

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/13956

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
